### PR TITLE
Fix Clang error "ISO C99 and later do not support implicit function declarations"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "linux-nvme-sys"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["MOZGIII <mike-n@narod.ru>"]
 edition = "2018"
 description = "Rust bindgen for nvme on linux"
@@ -8,7 +8,7 @@ license = "MIT"
 repository = "https://github.com/MOZGIII/linux-nvme-sys"
 
 [dependencies]
-nix = "0.15"
+nix = "0.26"
 
 [build-dependencies]
-bindgen = "0.51"
+bindgen = "0.66"

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,6 +1,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#define unlikely(x) x
+
 #include "nvme-cli/linux/nvme.h"
 #include "nvme-cli/linux/nvme_ioctl.h"
 #include "nvme-cli/linux/lightnvm.h"

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,6 +1,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+// In the nvme-cli, the `unlikely` macro is defined at `nvme-cli/nvme.h` -
+// but we do not want to include that, so we inline it instead.
+// This might hve to be changed when the `nvme-cli` submodule is updated to
+// a newer version.
 #define unlikely(x) x
 
 #include "nvme-cli/linux/nvme.h"


### PR DESCRIPTION
Adding the missing preprocessor definition and upgrading binfmt to 0.66 fixes #1 